### PR TITLE
Fix resource management and variable scope

### DIFF
--- a/lib/TerrainRgbHeight.js
+++ b/lib/TerrainRgbHeight.js
@@ -60,7 +60,7 @@ module.exports.convert = function(options, callback) {
             }
 
             //write out a 16 bit png
-            png = new PNG({
+            const png = new PNG({
                 width: w,
                 height: h,
                 bitDepth: 16,
@@ -76,7 +76,7 @@ module.exports.convert = function(options, callback) {
     })
     .on('error', function(err) {
         console.log(err);
-    });;
+    });
 };
 
 /* Converts a Terrain-RGB PNG to a 32 bit RGB image depicting height as grey values from 0 to 255.
@@ -129,7 +129,7 @@ module.exports.convert32 = function(options, callback) {
     })
     .on('error', function(err) {
         console.log(err);
-    });;
+    });
 };
 
 //converts height encoded in RGB values to a 16 bit integer elevation
@@ -143,11 +143,19 @@ var getHeightFromRgb = function(r, g, b) {
  * @param callback {Function} The callback for when the request is completed.
 */
 module.exports.getTile = function(url, outputFilePath, callback) {
-    request.head(url, function(err, res, body) {
+    request.head(url, function(err) {
+        if (err) {
+            return callback(err);
+        }
+
+        const out = fs.createWriteStream(outputFilePath);
+        out.on('error', callback);
+        out.on('finish', callback);
+
         request(url)
-        .pipe(fs.createWriteStream(outputFilePath, res.data)
-        .on('close', callback));
-    })
+            .on('error', callback)
+            .pipe(out);
+    });
 };
 
 /* Calculates the minimum and maximum values of a PNG file.
@@ -163,7 +171,7 @@ module.exports.calculateStatistics = function(inputFilePath, callback) {
     })
     .on('error', function(err) {
         console.log(err);
-    });;
+    });
 };
 
 /* Calculates the minimum and maximum values of a PNG.
@@ -171,7 +179,7 @@ module.exports.calculateStatistics = function(inputFilePath, callback) {
 * @returns {Object} An object containing the minimum and maximum height.
 */
 var getStatistics = function(png) {
-    stats = {};
+    const stats = {};
     stats.minHeight = Number.MAX_VALUE;
     stats.maxHeight = Number.MIN_VALUE;
     var h = png.height;


### PR DESCRIPTION
## Summary
- ensure PNGs in `convert` use a local const
- fix `getTile` write stream arguments and propagate errors
- make `stats` local inside `getStatistics`
- clean up stray semicolons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684783345724832885af88ad574a63a3